### PR TITLE
fix some bibcodes that don't exist anymore

### DIFF
--- a/data/sources/AT2018iih.json
+++ b/data/sources/AT2018iih.json
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 148.6,
       "e_vel_disp_km/s": 14.4,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2019azh.json
+++ b/data/sources/AT2019azh.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H+He",
    "spectral_subtype": "-",
-   "paper_ref": "2021MNRAS.500.1673H,2019arXiv191206081,2021ApJ...908....4V",
+   "paper_ref": "2021MNRAS.500.1673H,2022ApJ...925...67L,2021ApJ...908....4V",
    "nickname": "JaimeLannister",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 68.0,
       "e_vel_disp_km/s": 2.0,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2019cmw.json
+++ b/data/sources/AT2019cmw.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "Featureless",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "DavosSeaworth",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",

--- a/data/sources/AT2019dsg.json
+++ b/data/sources/AT2019dsg.json
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 86.9,
       "e_vel_disp_km/s": 3.9,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2020abri.json
+++ b/data/sources/AT2020abri.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "Unknown",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "Omera",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",

--- a/data/sources/AT2020acka.json
+++ b/data/sources/AT2020acka.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "Featureless",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "Grogu",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 174.47,
       "e_vel_disp_km/s": 25.3,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2020mot.json
+++ b/data/sources/AT2020mot.json
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 76.61,
       "e_vel_disp_km/s": 5.33,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2020neh.json
+++ b/data/sources/AT2020neh.json
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 40.0,
       "e_vel_disp_km/s": 6.0,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2020vdq.json
+++ b/data/sources/AT2020vdq.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "-",
    "spectral_subtype": "",
-   "paper_ref": "arXiv:2310.03791",
+   "paper_ref": "2023arXiv231003791S",
    "nickname": "J1008",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 43.6,
       "e_vel_disp_km/s": 3.1,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2020vwl.json
+++ b/data/sources/AT2020vwl.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H+He",
    "spectral_subtype": "-",
-   "paper_ref": "2023MNRAS.522.5084G,2023arXiv23030",
+   "paper_ref": "2023MNRAS.522.5084G,2023ApJ...955L...6Y",
    "nickname": "Mando",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 48.5,
       "e_vel_disp_km/s": 2.0,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2020wey.json
+++ b/data/sources/AT2020wey.json
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 39.36,
       "e_vel_disp_km/s": 2.79,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2020yue.json
+++ b/data/sources/AT2020yue.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H?",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "Wicket",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",

--- a/data/sources/AT2021axu.json
+++ b/data/sources/AT2021axu.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "Unknown",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "GreefKarga",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 73.5,
       "e_vel_disp_km/s": 17.26,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2021crk.json
+++ b/data/sources/AT2021crk.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H+He?",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "Kuiil",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 57.62,
       "e_vel_disp_km/s": 6.29,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2021ehb.json
+++ b/data/sources/AT2021ehb.json
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 99.58,
       "e_vel_disp_km/s": 3.83,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2021jjm.json
+++ b/data/sources/AT2021jjm.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "Pershing",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",

--- a/data/sources/AT2021mhg.json
+++ b/data/sources/AT2021mhg.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H+He",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "Burg",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 57.78,
       "e_vel_disp_km/s": 5.28,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2021nwa.json
+++ b/data/sources/AT2021nwa.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H+He",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "CobbVanth",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 102.44,
       "e_vel_disp_km/s": 5.37,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2021sdu.json
+++ b/data/sources/AT2021sdu.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H+He",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "ToroCalican",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",

--- a/data/sources/AT2021uqv.json
+++ b/data/sources/AT2021uqv.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "He",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "Q9-0",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 62.3,
       "e_vel_disp_km/s": 7.08,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2021utq.json
+++ b/data/sources/AT2021utq.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "Teebo",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",

--- a/data/sources/AT2021yte.json
+++ b/data/sources/AT2021yte.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "H+He",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "Lang",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",
@@ -115,7 +115,7 @@
    "host": {
       "vel_disp_km/s": 34.22,
       "e_vel_disp_km/s": 4.81,
-      "vel_disp_source": "Yao et al. 2023arXiv230306523Y",
+      "vel_disp_source": "Yao et al. 2023ApJ...955L...6Y",
       "note": "\nThe \"observations\" key constains the observed magnitudes, corrected for Galactic extinction. \nThe \"model\" key containts output from Prospector with FSPS (e.g., stellar mass). \nEach parameter is [median, lower, upper] range of the 68%CL interval.\nWe also give the synthetic observed magnitudes, these are also corrected for Galactic extinction. \nTo reverse the Galactic extinction correction, use the \"R_nu\" key.\nParameters with .0 indicate magnitudes in the galaxy rest-frame.\n",
       "Hubble_h": 0.7,
       "observations": {

--- a/data/sources/AT2021yzv.json
+++ b/data/sources/AT2021yzv.json
@@ -10,7 +10,7 @@
    "peak_limit": false,
    "spectral_type": "Featureless",
    "spectral_subtype": "-",
-   "paper_ref": "2023arXiv23030",
+   "paper_ref": "2023ApJ...955L...6Y",
    "nickname": "AxeWoves",
    "extinction": {
       "note": "\nExinction due to Galatic absorption to be applied to the TDE light.\nE(B-V) based on from maps of Schlegel, Finkbeiner & Davis (1998).\nWe use a blackbody with T=3e4K to find the linear extinction in each optical/UV band (similar to A_nu), \nwe also give the ratio of total-to-selective extinction (R_nu)\n",


### PR DESCRIPTION
Hey Sjoert,

I started playing around with this data for OTTER earlier and my code found 3 bibcodes that didn't exist on ADS. I think it's because they are old arxiv bibcodes instead of the updated journal bibcodes. The bibcodes (and one value that isn't a bibcode) are 
```
'2019arXiv191206081', 
'2023arXiv23030', 
'arXiv:2310.03791'
```
and these were across the following files
```
'AT2021axu.json',
 'AT2020abri.json',
 'AT2021sdu.json',
 'AT2019azh.json',
 'AT2021yzv.json',
 'AT2021uqv.json',
 'AT2021crk.json',
 'AT2021utq.json',
 'AT2019cmw.json',
 'AT2020vdq.json',
 'AT2021yte.json',
 'AT2020vwl.json',
 'AT2021nwa.json',
 'AT2020acka.json',
 'AT2021jjm.json',
 'AT2020yue.json',
 'AT2021mhg.json'
```

I just went through and replaced the nonexistent bibcodes with the following:
* 2019arXiv191206081 with 2022ApJ...925...67L
* 2023arXiv23030 with 2023ApJ...955L...6Y
* arXiv:2310.03791 with 2023arXiv231003791S

I thought I'd just fix it myself and open a PR instead of asking you to do more with this to save you some time :)